### PR TITLE
Update edit post url structure

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -55,7 +55,7 @@ export default function App(props: { disableCustomTheme?: boolean }) {
             />
             <Route path="/posts/:id" element={<PostDetail />} />
             <Route
-              path="/edit-post/:id"
+              path="/:id/edit"
               element={
                 <ProtectedRoute>
                   <EditPost />

--- a/frontend/src/components/EditPostButton.tsx
+++ b/frontend/src/components/EditPostButton.tsx
@@ -30,7 +30,7 @@ const EditButton: React.FC<EditButtonProps> = ({ id }) => {
     return null;
   }
 
-  const toRoute = `../edit-post/${encodeURIComponent(id)}`;
+  const toRoute = `../${encodeURIComponent(id)}/edit`;
 
   return (
     <IconButton

--- a/frontend/src/pages/CreatePost.tsx
+++ b/frontend/src/pages/CreatePost.tsx
@@ -44,7 +44,7 @@ export default function EditPost() {
     try {
       const createdPost = await postCommandService.create(value);
       showSnackbar("Post created successfully!", "success", () => {
-        navigate(`/edit-post/${createdPost.id}`);
+        navigate(`/${createdPost.id}/edit`);
       });
     } catch (err: any) {
       showSnackbar(`Failed to save post: ${err.message}`, "error");

--- a/frontend/tests/create-post-ui.ts
+++ b/frontend/tests/create-post-ui.ts
@@ -81,7 +81,7 @@ test.describe("Create Post UI", () => {
     await page.getByRole("button", { name: /close/i }).click();
 
     // Navigates to Edit Post page with created id
-    await expect(page).toHaveURL(/\/edit-post\/post-xyz$/);
+    await expect(page).toHaveURL(/\/post-xyz\/edit$/);
     await expect(page.locator("h1")).toHaveText("Edit Post");
   });
 

--- a/frontend/tests/edit-post-ui.spec.ts
+++ b/frontend/tests/edit-post-ui.spec.ts
@@ -31,7 +31,7 @@ async function gotoEditPost(page: any, baseURL?: string | undefined, id = "post-
     });
   });
 
-  await page.goto(`${trimmed}/edit-post/${id}`);
+  await page.goto(`${trimmed}/${id}/edit`);
 }
 
 test.describe("Edit Post UI - Zod validation", () => {


### PR DESCRIPTION
Update edit post URL from `/edit-post/:id` to `/:id/edit` across routes, links, and tests.

---
<a href="https://cursor.com/background-agent?bcId=bc-80496f42-a52f-4fa7-a9bf-e2a6856abbee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-80496f42-a52f-4fa7-a9bf-e2a6856abbee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

